### PR TITLE
Fix joy.h compile error on some platforms

### DIFF
--- a/src/module/joy_stick_module/joy.h
+++ b/src/module/joy_stick_module/joy.h
@@ -34,6 +34,7 @@
 #include <future>
 #include <memory>
 #include <string>
+#include <vector>
 #include <thread>
 
 using namespace std::chrono;


### PR DESCRIPTION
std::vector declaration raised some error during building this afternoon in my environment, add header include could fix this.